### PR TITLE
Fixes to Qnet

### DIFF
--- a/gan.py
+++ b/gan.py
@@ -107,9 +107,11 @@ class QNet(tf.keras.Model):
         return z
     
     def call(self, x, training=True):
-        q = self.Qd(x)
-        q = self.Qb(x, training=training)
-        q = self.Qa(x)
+        x = self.Qd(x)
+        x = self.Qb(x, training=training)
+        x = self.Qa(x)
+        
+        q = x
         
         Q_cat = self.Q_cat(q)
 

--- a/train.py
+++ b/train.py
@@ -133,7 +133,7 @@ def train_step(images, step):
     gen_grd = gen_tape.gradient(gi, generator.trainable_variables + qnet.trainable_variables)
     dis_grd = dis_tape.gradient(di, discriminator.trainable_variables)
     
-    gen_opt.apply_gradients(zip(gen_grd, generator.trainable_variables))
+    gen_opt.apply_gradients(zip(gen_grd, generator.trainable_variables + qnet.trainable_variables))
     dis_opt.apply_gradients(zip(dis_grd, discriminator.trainable_variables))
     
     return gen_loss, dis_loss


### PR DESCRIPTION
Previously, the Qnet layers were skipped over and not trained with the gradients, these changes resolve the issues. This allows for faster convergence and better pairing of a single number to each categorical value.  See results demonstration below:

![infogan_mnist](https://user-images.githubusercontent.com/29410997/99419822-86806b80-28ca-11eb-93c1-9685253e3c05.gif)
